### PR TITLE
Improved Windows support for `npm test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 test:
-	@./node_modules/.bin/lab
+	node node_modules/lab/bin/lab
 test-cov: 
-	@./node_modules/.bin/lab -r threshold -t 100
+	node node_modules/lab/bin/lab -r threshold -t 100
 test-cov-html:
-	@./node_modules/.bin/lab -r html -o coverage.html
+	node node_modules/lab/bin/lab -r html -o coverage.html
 complexity:
-	@./node_modules/.bin/cr -o complexity.md -f markdown lib
+	node node_modules/complexity-report/src/cli.js -o complexity.md -f markdown lib
 
 .PHONY: test test-cov test-cov-html complexity
 


### PR DESCRIPTION
Windows doesn't handle dot slash notation well, so I substituted for fuller, but still relative paths to the local Node.js CLI tools in `Makefile`.
