### PR TITLE
Avoid using deprecated Buffer API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,11 +94,7 @@ exports.time = async function (options = {}) {
 
     // Construct NTP message
 
-    const message = new Buffer(48);
-    for (let i = 0; i < 48; ++i) {                      // Zero message
-        message[i] = 0;
-    }
-
+    const message = Buffer.alloc(48);                   // Zero-filled message
     message[0] = (0 << 6) + (4 << 3) + (3 << 0);        // Set version number to 4 and Mode to 3 (client)
     const sent = Date.now();
     internals.fromMsecs(sent, message, 40);             // Set transmit timestamp (returns as originate)


### PR DESCRIPTION
`Buffer.alloc` creates a zero-filled buffer, supported since Node.js 4.5.0
That is well below the current Node.js version requirement (>=8.9.0) and async usage.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor